### PR TITLE
Potential fix for code scanning alert no. 1: Use of a weak cryptographic key

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,5 @@
 const NodeRSA = require("node-rsa");
-const key = new NodeRSA({ b: 512 });
+const key = new NodeRSA({ b: 2048 });
 console.log('public :'+key.exportKey('public'))
 console.log('private: '+key.exportKey('private'))      
 let a = key.exportKey('public').replace(/-----BEGIN PUBLIC KEY-----|-----END PUBLIC KEY-----/g, '').replace(/\n/g, '~')


### PR DESCRIPTION
Potential fix for [https://github.com/Pratyay360/secure-exchange/security/code-scanning/1](https://github.com/Pratyay360/secure-exchange/security/code-scanning/1)

To fix the issue, the RSA key size should be increased to at least 2048 bits, as recommended for secure cryptographic operations. This change ensures that the key is sufficiently strong to resist modern computational attacks. The modification involves updating the key generation line to specify a key size of 2048 bits instead of 512 bits. No additional changes to the functionality of the code are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
